### PR TITLE
Add LightApcuAdapter as a light-weight alternative to Symfony Cache's

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,24 +12,26 @@ jobs:
 
     steps:
       # Check out the repository under $GITHUB_WORKSPACE, so this job can access it.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          # Ensure ext-apcu is installed for running tests against.
+          extensions: 'apcu'
 
       - name: Install Composer dependencies
         run: composer install
 
       - name: Run tests
-        run: vendor/bin/phpunit
+        run: php -d apc.enable_cli=On vendor/bin/phpunit
 
   phpstan:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use PHP 8.2
         uses: shivammathur/setup-php@v2

--- a/composer.lock
+++ b/composer.lock
@@ -204,20 +204,20 @@
     "packages-dev": [
         {
             "name": "asmblah/php-code-shift",
-            "version": "v0.1.15",
+            "version": "v0.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/asmblah/php-code-shift.git",
-                "reference": "aefd687c615c9050c1185db1f2539699f9ab1ba5"
+                "reference": "bd0cb9685dc13d673e832078bc32240950fe1394"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/asmblah/php-code-shift/zipball/aefd687c615c9050c1185db1f2539699f9ab1ba5",
-                "reference": "aefd687c615c9050c1185db1f2539699f9ab1ba5",
+                "url": "https://api.github.com/repos/asmblah/php-code-shift/zipball/bd0cb9685dc13d673e832078bc32240950fe1394",
+                "reference": "bd0cb9685dc13d673e832078bc32240950fe1394",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.16",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "nytris/nytris": "^0.1",
                 "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
@@ -244,9 +244,9 @@
             ],
             "support": {
                 "issues": "https://github.com/asmblah/php-code-shift/issues",
-                "source": "https://github.com/asmblah/php-code-shift/tree/v0.1.15"
+                "source": "https://github.com/asmblah/php-code-shift/tree/v0.1.17"
             },
-            "time": "2024-08-21T01:41:43+00:00"
+            "time": "2024-10-07T00:56:47+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -444,25 +444,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.1",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b"
+                "reference": "3abf7425cd284141dc5d8d14a9ee444de3345d1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4e1b88d21c69391150ace211e9eaf05810858d0b",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3abf7425cd284141dc5d8d14a9ee444de3345d1a",
+                "reference": "3abf7425cd284141dc5d8d14a9ee444de3345d1a",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -470,7 +472,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -494,9 +496,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.0"
             },
-            "time": "2024-03-17T08:10:35+00:00"
+            "time": "2024-09-29T13:56:26+00:00"
         },
         {
             "name": "nytris/nytris",
@@ -660,16 +662,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.11",
+            "version": "1.12.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "707c2aed5d8d0075666e673a5e71440c1d01a5a3"
+                "reference": "dc4d2f145a88ea7141ae698effd64d9df46527ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/707c2aed5d8d0075666e673a5e71440c1d01a5a3",
-                "reference": "707c2aed5d8d0075666e673a5e71440c1d01a5a3",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc4d2f145a88ea7141ae698effd64d9df46527ae",
+                "reference": "dc4d2f145a88ea7141ae698effd64d9df46527ae",
                 "shasum": ""
             },
             "require": {
@@ -714,32 +716,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-19T14:37:29+00:00"
+            "time": "2024-10-06T15:03:59+00:00"
         },
         {
             "name": "phpstan/phpstan-mockery",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-mockery.git",
-                "reference": "88ae85931768efd3aaf3cce4cb9cb54c4d157d03"
+                "reference": "98cac6e256b4ee60fdeb26a7dd81bb271b454e80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/88ae85931768efd3aaf3cce4cb9cb54c4d157d03",
-                "reference": "88ae85931768efd3aaf3cce4cb9cb54c4d157d03",
+                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/98cac6e256b4ee60fdeb26a7dd81bb271b454e80",
+                "reference": "98cac6e256b4ee60fdeb26a7dd81bb271b454e80",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.10"
+                "phpstan/phpstan": "^1.12"
             },
             "require-dev": {
-                "mockery/mockery": "^1.2.4",
+                "mockery/mockery": "^1.6.11",
                 "nikic/php-parser": "^4.13.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan-strict-rules": "^1.6",
                 "phpunit/phpunit": "^9.5"
             },
             "type": "phpstan-extension",
@@ -762,9 +764,9 @@
             "description": "PHPStan Mockery extension",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-mockery/issues",
-                "source": "https://github.com/phpstan/phpstan-mockery/tree/1.1.2"
+                "source": "https://github.com/phpstan/phpstan-mockery/tree/1.1.3"
             },
-            "time": "2024-01-10T13:50:05+00:00"
+            "time": "2024-09-11T15:47:29+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1089,16 +1091,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.30",
+            "version": "10.5.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b15524febac0153876b4ba9aab3326c2ee94c897"
+                "reference": "aa0a8ce701ea7ee314b0dfaa8970dc94f3f8c870"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b15524febac0153876b4ba9aab3326c2ee94c897",
-                "reference": "b15524febac0153876b4ba9aab3326c2ee94c897",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/aa0a8ce701ea7ee314b0dfaa8970dc94f3f8c870",
+                "reference": "aa0a8ce701ea7ee314b0dfaa8970dc94f3f8c870",
                 "shasum": ""
             },
             "require": {
@@ -1112,7 +1114,7 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.15",
+                "phpunit/php-code-coverage": "^10.1.16",
                 "phpunit/php-file-iterator": "^4.1.0",
                 "phpunit/php-invoker": "^4.0.0",
                 "phpunit/php-text-template": "^3.0.1",
@@ -1170,7 +1172,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.30"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.36"
             },
             "funding": [
                 {
@@ -1186,7 +1188,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-13T06:09:37+00:00"
+            "time": "2024-10-08T15:36:51+00:00"
         },
         {
             "name": "psr/container",
@@ -1243,16 +1245,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "79dff0b268932c640297f5208d6298f71855c03e"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/79dff0b268932c640297f5208d6298f71855c03e",
-                "reference": "79dff0b268932c640297f5208d6298f71855c03e",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
@@ -1287,9 +1289,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.1"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2024-08-21T13:31:24+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "react/event-loop",
@@ -2281,16 +2283,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v5.4.42",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "6f5f750692bd5a212e01a4f1945fd856bceef89e"
+                "reference": "4b3e7bf157b8b5a010865701d9106b5f0a9c99a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/6f5f750692bd5a212e01a4f1945fd856bceef89e",
-                "reference": "6f5f750692bd5a212e01a4f1945fd856bceef89e",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/4b3e7bf157b8b5a010865701d9106b5f0a9c99a8",
+                "reference": "4b3e7bf157b8b5a010865701d9106b5f0a9c99a8",
                 "shasum": ""
             },
             "require": {
@@ -2358,7 +2360,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v5.4.42"
+                "source": "https://github.com/symfony/cache/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -2374,7 +2376,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-10T06:02:18+00:00"
+            "time": "2024-09-13T16:57:39+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -2524,16 +2526,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.41",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "6d29dd9340b372fa603f04e6df4dd76bb808591e"
+                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6d29dd9340b372fa603f04e6df4dd76bb808591e",
-                "reference": "6d29dd9340b372fa603f04e6df4dd76bb808591e",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/76c3818964e9d32be3862c9318ae3ba9aa280ddc",
+                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc",
                 "shasum": ""
             },
             "require": {
@@ -2571,7 +2573,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.41"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -2587,24 +2589,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:36:24+00:00"
+            "time": "2024-09-16T14:52:48+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-ctype": "*"
@@ -2650,7 +2652,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2666,24 +2668,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
-                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-mbstring": "*"
@@ -2730,7 +2732,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2746,24 +2748,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-19T12:30:46+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "ec444d3f3f6505bb28d11afa41e75faadebc10a1"
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/ec444d3f3f6505bb28d11afa41e75faadebc10a1",
-                "reference": "ec444d3f3f6505bb28d11afa41e75faadebc10a1",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
@@ -2806,7 +2808,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2822,24 +2824,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
-                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
@@ -2886,7 +2888,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2902,7 +2904,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -1,0 +1,11 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#1 \\$expiration of method Nytris\\\\Cache\\\\Adapter\\\\LightCacheItem\\:\\:expiresAt\\(\\) expects DateTimeInterface\\|null, string given\\.$#"
+			count: 1
+			path: tests/Unit/Adapter/LightCacheItemTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$time of method Nytris\\\\Cache\\\\Adapter\\\\LightCacheItem\\:\\:expiresAfter\\(\\) expects DateInterval\\|int\\|null, string given\\.$#"
+			count: 1
+			path: tests/Unit/Adapter/LightCacheItemTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 includes:
     - vendor/phpstan/phpstan-mockery/extension.neon
+    - phpstan-baseline.neon.dist
 
 parameters:
     level: 6

--- a/src/Adapter/LightApcuAdapter.php
+++ b/src/Adapter/LightApcuAdapter.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * Nytris Cache
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/cache/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/cache/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Cache\Adapter;
+
+use APCUIterator;
+use BadMethodCallException;
+use InvalidArgumentException;
+use LogicException;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use const APC_ITER_KEY;
+
+/**
+ * Class LightApcuAdapter.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class LightApcuAdapter implements CacheItemPoolInterface
+{
+    public function __construct(
+        private readonly string $namespace = '',
+        private readonly int $defaultLifetime = 0
+    ) {
+        if (!self::isSupported()) {
+            throw new LogicException('APCu is not enabled');
+        }
+
+        class_exists(LightCacheItem::class);
+    }
+
+    private function buildKey(string $key): string
+    {
+        return $this->namespace . '/' . $key;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): bool
+    {
+        return apcu_delete(
+            new APCUIterator(
+                sprintf('/^%s/', preg_quote($this->namespace, '/')),
+                APC_ITER_KEY
+            )
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function commit(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteItem($key): bool
+    {
+        return apcu_delete($this->buildKey($key));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteItems(array $keys): bool
+    {
+        throw new BadMethodCallException(__METHOD__ . '() :: Not implemented');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getItem($key): CacheItemInterface
+    {
+        $value = apcu_fetch($this->buildKey($key), success: $isHit);
+
+        return new LightCacheItem(
+            isHit: $isHit,
+            key: $key,
+            value: $isHit ? $value : null
+        );
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return array<string, CacheItemInterface>
+     */
+    public function getItems(array $keys = array()): iterable
+    {
+        throw new BadMethodCallException(__METHOD__ . '() :: Not implemented');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasItem($key): bool
+    {
+        return apcu_exists($this->buildKey($key));
+    }
+
+    /**
+     * Determines whether APCu is available so that this adapter can be used.
+     */
+    public static function isSupported(): bool
+    {
+        return function_exists('apcu_enabled') && apcu_enabled();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function save(CacheItemInterface $item): bool
+    {
+        if (!($item instanceof LightCacheItem)) {
+            throw new InvalidArgumentException('$item must be a LightCacheItem');
+        }
+
+        return apcu_store(
+            $this->buildKey($item->getKey()),
+            $item->get(),
+            $item->getExpiry() !== null ?
+                (int) ($item->getExpiry() - microtime(as_float: true)) :
+                $this->defaultLifetime
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->save($item);
+    }
+}

--- a/src/Adapter/LightCacheItem.php
+++ b/src/Adapter/LightCacheItem.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * Nytris Cache
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/cache/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/cache/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Cache\Adapter;
+
+use DateInterval;
+use DateTime;
+use DateTimeInterface;
+use InvalidArgumentException;
+use Psr\Cache\CacheItemInterface;
+use function is_int;
+
+/**
+ * Class LightCacheItem.
+ *
+ * Based on Symfony Cache's CacheItem class.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class LightCacheItem implements CacheItemInterface
+{
+    private ?float $expiry = null;
+
+    public function __construct(
+        private readonly bool $isHit,
+        private readonly string $key,
+        private mixed $value
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function expiresAfter($time): CacheItemInterface
+    {
+        if (null === $time) {
+            $this->expiry = null;
+        } elseif ($time instanceof DateInterval) {
+            $this->expiry = microtime(true) +
+                (float) (DateTime::createFromFormat('U', '0')->add($time)->format('U.u'));
+        } elseif (is_int($time)) {
+            $this->expiry = $time + microtime(as_float: true);
+        } else {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Expiration date must be an integer, a DateInterval or null, "%s" given.',
+                    get_debug_type($time)
+                )
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function expiresAt($expiration): CacheItemInterface
+    {
+        if ($expiration === null) {
+            $this->expiry = null;
+        } elseif ($expiration instanceof DateTimeInterface) {
+            $this->expiry = (float) $expiration->format('U.u');
+        } else {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Expiration date must implement DateTimeInterface or be null, "%s" given.',
+                    get_debug_type($expiration)
+                )
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get(): mixed
+    {
+        return $this->value;
+    }
+
+    /**
+     * Fetches the expiry time set for this cache item, or null if none.
+     */
+    public function getExpiry(): ?float
+    {
+        return $this->expiry;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHit(): bool
+    {
+        return $this->isHit;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set(mixed $value): CacheItemInterface
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+}

--- a/tests/Functional/Adapter/LightApcuAdapterTest.php
+++ b/tests/Functional/Adapter/LightApcuAdapterTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * Nytris Cache
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/cache/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/cache/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Cache\Tests\Functional\Adapter;
+
+use BadMethodCallException;
+use DateTimeImmutable;
+use Nytris\Cache\Adapter\LightApcuAdapter;
+use Nytris\Cache\Adapter\LightCacheItem;
+use Nytris\Cache\Tests\Functional\AbstractFunctionalTestCase;
+
+/**
+ * Class LightApcuAdapterTest.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class LightApcuAdapterTest extends AbstractFunctionalTestCase
+{
+    private LightApcuAdapter $adapter;
+
+    protected function setUp(): void
+    {
+        if (!LightApcuAdapter::isSupported()) {
+            $this->markTestSkipped('APCu is not enabled.');
+        }
+
+        apcu_clear_cache();
+
+        $this->adapter = new LightApcuAdapter(namespace: 'test_namespace', defaultLifetime: 3600);
+    }
+
+    public function testClearRemovesAllItemsInNamespace(): void
+    {
+        apcu_store('test_namespace/item1', 'value1');
+        apcu_store('test_namespace/item2', 'value2');
+        apcu_store('other_namespace/item3', 'value3');
+
+        // Clear the namespace "test_namespace".
+        static::assertTrue($this->adapter->clear());
+
+        static::assertFalse(apcu_exists('test_namespace/item1'));
+        static::assertFalse(apcu_exists('test_namespace/item2'));
+        static::assertTrue(
+            apcu_exists('other_namespace/item3'),
+            'Item from another namespace should remain'
+        );
+    }
+
+    public function testDeleteItemRemovesSpecificItem(): void
+    {
+        apcu_store('test_namespace/item1', 'value1');
+
+        static::assertTrue(apcu_exists('test_namespace/item1'));
+        static::assertTrue($this->adapter->deleteItem('item1'));
+        static::assertFalse(apcu_exists('test_namespace/item1'));
+    }
+
+    public function testDeleteItemsThrowsBadMethodCallException(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('::deleteItems() :: Not implemented');
+
+        $this->adapter->deleteItems(['item1', 'item2']);
+    }
+
+    public function testGetItemRetrievesStoredItem(): void
+    {
+        apcu_store('test_namespace/item1', 'value1');
+
+        $item = $this->adapter->getItem('item1');
+
+        static::assertInstanceOf(LightCacheItem::class, $item);
+        static::assertTrue($item->isHit());
+        static::assertSame('value1', $item->get());
+    }
+
+    public function testGetItemReturnsMissWhenItemNotInCache(): void
+    {
+        $item = $this->adapter->getItem('nonexistent_item');
+
+        static::assertInstanceOf(LightCacheItem::class, $item);
+        static::assertFalse($item->isHit());
+        static::assertNull($item->get());
+    }
+
+    public function testGetItemsThrowsBadMethodCallException(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('::getItems() :: Not implemented');
+
+        $this->adapter->getItems(['item1', 'item2']);
+    }
+
+    public function testHasItemReturnsTrueWhenItemExists(): void
+    {
+        apcu_store('test_namespace/item1', 'value1');
+
+        static::assertTrue($this->adapter->hasItem('item1'));
+    }
+
+    public function testHasItemReturnsFalseWhenItemDoesNotExist(): void
+    {
+        static::assertFalse($this->adapter->hasItem('nonexistent_item'));
+    }
+
+    public function testIsSupportedWhenApcuIsAvailable(): void
+    {
+        static::assertTrue(LightApcuAdapter::isSupported());
+    }
+
+    public function testSaveStoresCacheItem(): void
+    {
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+
+        static::assertTrue($this->adapter->save($cacheItem));
+        static::assertSame('value1', apcu_fetch('test_namespace/item1'));
+    }
+
+    public function testSaveStoresItemWithExpiresAt(): void
+    {
+        $expiryTime = new DateTimeImmutable('+2 seconds');
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+        $cacheItem->expiresAt($expiryTime);
+
+        static::assertTrue($this->adapter->save($cacheItem));
+        static::assertTrue($this->adapter->hasItem('item1'), 'Item should exist before expiring');
+        sleep(3); // Allow item to expire.
+        static::assertFalse($this->adapter->hasItem('item1'), 'Item should no longer exist');
+    }
+
+    public function testSaveStoresItemWithExpiresAfter(): void
+    {
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+        $cacheItem->expiresAfter(2); // 2 seconds
+
+        static::assertTrue($this->adapter->save($cacheItem));
+        static::assertTrue($this->adapter->hasItem('item1'), 'Item should exist before expiring');
+        sleep(3); // Allow item to expire.
+        static::assertFalse($this->adapter->hasItem('item1'), 'Item should no longer exist');
+    }
+
+    public function testSaveStoresItemWithDefaultLifetime(): void
+    {
+        // Default lifetime for this adapter is 3600 seconds (1 hour).
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+
+        static::assertTrue($this->adapter->save($cacheItem)); // Save item without specifying TTL.
+        static::assertTrue($this->adapter->hasItem('item1'), 'Item should exist before expiring');
+        // Sleep for a brief period (should still be present, since 3600 seconds has not passed).
+        sleep(2);
+        static::assertTrue($this->adapter->hasItem('item1'), 'Item should still be present');
+    }
+
+    public function testSaveStoresItemWithCustomDefaultLifetime(): void
+    {
+        // Create a new adapter with a short default lifetime (2 seconds).
+        $this->adapter = new LightApcuAdapter(namespace: 'test_namespace', defaultLifetime: 2);
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+
+        static::assertTrue($this->adapter->save($cacheItem)); // Save item without specifying TTL.
+        static::assertTrue($this->adapter->hasItem('item1'), 'Item should exist before expiring');
+        sleep(3); // Allow item to expire.
+        static::assertFalse($this->adapter->hasItem('item1'), 'Item should no longer exist');
+    }
+
+    public function testSaveItemWithNoExpirationKeepsItemInCache(): void
+    {
+        // Use a custom adapter with no default lifetime (infinite lifetime).
+        $this->adapter = new LightApcuAdapter(namespace: 'test_namespace', defaultLifetime: 0);
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+
+        // Save the item without setting TTL, meaning it should persist indefinitely.
+        static::assertTrue($this->adapter->save($cacheItem));
+        static::assertTrue($this->adapter->hasItem('item1'), 'Item should exist before expiring');
+        // Sleep for a while (the item should still be present because it has no TTL).
+        sleep(3);
+        static::assertTrue($this->adapter->hasItem('item1'), 'Item should still be present');
+    }
+
+    public function testSaveDeferredIsAliasOfSave(): void
+    {
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+
+        static::assertTrue($this->adapter->saveDeferred($cacheItem));
+        static::assertSame('value1', apcu_fetch('test_namespace/item1'));
+    }
+}

--- a/tests/Unit/Adapter/LightCacheItemTest.php
+++ b/tests/Unit/Adapter/LightCacheItemTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * Nytris Cache
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/cache/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/cache/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Cache\Tests\Unit\Adapter;
+
+use DateInterval;
+use DateTime;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Nytris\Cache\Adapter\LightCacheItem;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * Class LightCacheItemTest.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class LightCacheItemTest extends TestCase
+{
+    private LightCacheItem $cacheItem;
+
+    protected function setUp(): void
+    {
+        $this->cacheItem = new LightCacheItem(isHit: true, key: 'test_key', value: 'test_value');
+    }
+
+    public function testImplementsCacheItemInterface(): void
+    {
+        static::assertInstanceOf(CacheItemInterface::class, $this->cacheItem);
+    }
+
+    public function testExpiresAfterSetsExpiryWhenIntervalIsPassed(): void
+    {
+        $interval = new DateInterval('PT2S'); // 2 seconds.
+        $this->cacheItem->expiresAfter($interval);
+
+        $expectedExpiry = microtime(true) + 2.0;
+        $actualExpiry = $this->cacheItem->getExpiry();
+
+        static::assertNotNull($actualExpiry);
+        static::assertGreaterThanOrEqual($expectedExpiry - 0.01, $actualExpiry);
+        static::assertLessThanOrEqual($expectedExpiry + 0.01, $actualExpiry);
+    }
+
+    public function testExpiresAfterSetsExpiryWhenIntegerIsPassed(): void
+    {
+        $this->cacheItem->expiresAfter(2); // 2 seconds.
+
+        $expectedExpiry = microtime(true) + 2.0;
+        $actualExpiry = $this->cacheItem->getExpiry();
+
+        static::assertNotNull($actualExpiry);
+        static::assertGreaterThanOrEqual($expectedExpiry - 0.01, $actualExpiry);
+        static::assertLessThanOrEqual($expectedExpiry + 0.01, $actualExpiry);
+    }
+
+    public function testExpiresAfterSetsNullExpiryWhenNullIsPassed(): void
+    {
+        $this->cacheItem->expiresAfter(null);
+
+        static::assertNull($this->cacheItem->getExpiry());
+    }
+
+    public function testExpiresAfterThrowsExceptionForInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expiration date must be an integer, a DateInterval or null, "string" given.');
+
+        $this->cacheItem->expiresAfter('invalid');
+    }
+
+    public function testExpiresAtSetsExpiryWhenDateTimeImmutableIsPassed(): void
+    {
+        $expiryTime = new DateTimeImmutable('+2 seconds');
+        $this->cacheItem->expiresAt($expiryTime);
+
+        $expectedExpiry = (float) $expiryTime->format('U.u');
+        $actualExpiry = $this->cacheItem->getExpiry();
+
+        static::assertNotNull($actualExpiry);
+        static::assertSame($expectedExpiry, $actualExpiry);
+    }
+
+    public function testExpiresAtSetsExpiryWhenDateTimeIsPassed(): void
+    {
+        $expiryTime = new DateTime('+2 seconds');
+        $this->cacheItem->expiresAt($expiryTime);
+
+        $expectedExpiry = (float) $expiryTime->format('U.u');
+        $actualExpiry = $this->cacheItem->getExpiry();
+
+        static::assertNotNull($actualExpiry);
+        static::assertSame($expectedExpiry, $actualExpiry);
+    }
+
+    public function testExpiresAtSetsNullExpiryWhenNullIsPassed(): void
+    {
+        $this->cacheItem->expiresAt(null);
+
+        static::assertNull($this->cacheItem->getExpiry());
+    }
+
+    public function testExpiresAtThrowsExceptionForInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expiration date must implement DateTimeInterface or be null, "string" given.');
+
+        $this->cacheItem->expiresAt('invalid');
+    }
+
+    public function testGetReturnsTheValue(): void
+    {
+        static::assertSame('test_value', $this->cacheItem->get());
+    }
+
+    public function testGetExpiryReturnsCorrectExpiryTimeAfterExpiresAt(): void
+    {
+        $expiryTime = new DateTimeImmutable('+2 seconds');
+        $this->cacheItem->expiresAt($expiryTime);
+
+        $expectedExpiry = (float) $expiryTime->format('U.u');
+        static::assertSame($expectedExpiry, $this->cacheItem->getExpiry());
+    }
+
+    public function testGetExpiryReturnsNullIfNoExpirySet(): void
+    {
+        static::assertNull($this->cacheItem->getExpiry());
+    }
+
+    public function testGetKeyReturnsTheKey(): void
+    {
+        static::assertSame('test_key', $this->cacheItem->getKey());
+    }
+
+    public function testIsHitReturnsTrueWhenHit(): void
+    {
+        static::assertTrue($this->cacheItem->isHit());
+    }
+
+    public function testSetUpdatesTheValue(): void
+    {
+        $this->cacheItem->set('new_value');
+
+        static::assertSame('new_value', $this->cacheItem->get());
+    }
+}


### PR DESCRIPTION
A more efficient simpler implementation, that does not support value marshalling or otherwise, but is suitable for storing any value that APCu supports natively.