### PR TITLE
Fix bug where an expiry of now was being treated as infinite

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,31 @@ $bootConfig->installPackage(new MyNytrisPackage(
 return $bootConfig;
 ```
 
+### LightApcuAdapter
+
+This is a thin, lightweight, minimal wrapper around APCu that implements the PSR-6 interface.
+
+Usage:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Nytris\Cache\Adapter\LightApcuAdapter;
+
+$adapter = new LightApcuAdapter(
+    namespace: 'my_namespace', // Defaults to the empty string.
+    defaultLifetime: 3600      // Defaults to 0 / no expiry.
+);
+
+$cacheItem = $adapter->getItem('my_key');
+$cacheItem->set('my_value');
+$cacheItem->expiresAfter(2); // Set to expire 2 seconds from now.
+
+$adapter->save($cacheItem);
+```
+
 ### Caveats
 
 - PSR-6 cache adapters may block, if so then the ReactPHP event loop will be blocked.

--- a/src/Adapter/LightApcuAdapter.php
+++ b/src/Adapter/LightApcuAdapter.php
@@ -130,12 +130,27 @@ class LightApcuAdapter implements CacheItemPoolInterface
             throw new InvalidArgumentException('$item must be a LightCacheItem');
         }
 
+        $expiry = $item->getExpiry();
+
+        if ($expiry === null) {
+            // No expiry is set for the item, so we use the default lifetime,
+            // which may be 0 to indicate infinite lifetime.
+            $ttl = $this->defaultLifetime;
+        } else {
+            // A non-infinite specific expiry time was set for the item.
+            $ttl = (int) ($expiry - microtime(as_float: true));
+
+            if ($ttl === 0) {
+                // A TTL of 0 would actually tell apcu_store(...) to store infinitely,
+                // rather than for 0 seconds, so we skip storage.
+                return true;
+            }
+        }
+
         return apcu_store(
             $this->buildKey($item->getKey()),
             $item->get(),
-            $item->getExpiry() !== null ?
-                (int) ($item->getExpiry() - microtime(as_float: true)) :
-                $this->defaultLifetime
+            $ttl
         );
     }
 

--- a/tests/Functional/Adapter/LightApcuAdapterTest.php
+++ b/tests/Functional/Adapter/LightApcuAdapterTest.php
@@ -84,6 +84,17 @@ class LightApcuAdapterTest extends AbstractFunctionalTestCase
         static::assertSame('value1', $item->get());
     }
 
+    public function testGetItemRetrievesStoredItemWithBooleanFalseAsValue(): void
+    {
+        apcu_store('test_namespace/item1', false);
+
+        $item = $this->adapter->getItem('item1');
+
+        static::assertInstanceOf(LightCacheItem::class, $item);
+        static::assertTrue($item->isHit());
+        static::assertFalse($item->get());
+    }
+
     public function testGetItemReturnsMissWhenItemNotInCache(): void
     {
         $item = $this->adapter->getItem('nonexistent_item');
@@ -126,7 +137,16 @@ class LightApcuAdapterTest extends AbstractFunctionalTestCase
         static::assertSame('value1', apcu_fetch('test_namespace/item1'));
     }
 
-    public function testSaveStoresItemWithExpiresAt(): void
+    public function testSaveStoresCacheItemWithBooleanFalseAsValue(): void
+    {
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: false);
+
+        static::assertTrue($this->adapter->save($cacheItem));
+        static::assertFalse(apcu_fetch('test_namespace/item1', $success));
+        static::assertTrue($success);
+    }
+
+    public function testSaveStoresItemWithFutureExpiresAt(): void
     {
         $expiryTime = new DateTimeImmutable('+2 seconds');
         $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
@@ -138,15 +158,53 @@ class LightApcuAdapterTest extends AbstractFunctionalTestCase
         static::assertFalse($this->adapter->hasItem('item1'), 'Item should no longer exist');
     }
 
-    public function testSaveStoresItemWithExpiresAfter(): void
+    public function testSaveDoesNotStoreItemWithExpiresAtOfNow(): void
+    {
+        $now = new DateTimeImmutable();
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+        $cacheItem->expiresAt($now);
+
+        static::assertTrue($this->adapter->save($cacheItem));
+        static::assertFalse($this->adapter->hasItem('item1'), 'Item should not be stored');
+    }
+
+    public function testSaveDoesNotStoreItemWithPastExpiresAt(): void
+    {
+        $expiryTime = new DateTimeImmutable('-2 seconds');
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+        $cacheItem->expiresAt($expiryTime);
+
+        static::assertTrue($this->adapter->save($cacheItem));
+        static::assertFalse($this->adapter->hasItem('item1'), 'Item should not be stored');
+    }
+
+    public function testSaveStoresItemWithFutureExpiresAfter(): void
     {
         $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
-        $cacheItem->expiresAfter(2); // 2 seconds
+        $cacheItem->expiresAfter(2); // 2 seconds from now.
 
         static::assertTrue($this->adapter->save($cacheItem));
         static::assertTrue($this->adapter->hasItem('item1'), 'Item should exist before expiring');
         sleep(3); // Allow item to expire.
         static::assertFalse($this->adapter->hasItem('item1'), 'Item should no longer exist');
+    }
+
+    public function testSaveDoesNotStoreItemWithZeroExpiresAfter(): void
+    {
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+        $cacheItem->expiresAfter(0); // Right now.
+
+        static::assertTrue($this->adapter->save($cacheItem));
+        static::assertFalse($this->adapter->hasItem('item1'), 'Item should not be stored');
+    }
+
+    public function testSaveDoesNotStoreItemWithNegativeExpiresAfter(): void
+    {
+        $cacheItem = new LightCacheItem(isHit: true, key: 'item1', value: 'value1');
+        $cacheItem->expiresAfter(-2); // 2 seconds ago.
+
+        static::assertTrue($this->adapter->save($cacheItem));
+        static::assertFalse($this->adapter->hasItem('item1'), 'Item should not be stored');
     }
 
     public function testSaveStoresItemWithDefaultLifetime(): void


### PR DESCRIPTION
`apcu_store(...)` stores items with no defined expiry when the `$ttl` parameter's argument is `0`.

This was causing items with an expiry timestamp of now to incorrectly be stored indefinitely.